### PR TITLE
Add Home Assistant MQTT integration

### DIFF
--- a/src/code.py
+++ b/src/code.py
@@ -19,24 +19,19 @@ status = Status()
 
 try:
     # network handles functionality for connecting to wifi, connecting to the NTP server.
-    #TODO: Connect to mqtt server inside network?
     network = WifiNetwork()
 except Exception as e:
     print('Network Failure. ', e)
-    #TODO: Abort until we have a network. 
-    #TODO: Give an LED warning of some type
 
-#data = Data(network.get_wifi_socketpool)
-data = Data()
-button = keypad.Keys((INPUT_BUTTON,), value_when_pressed=False, pull=True)
 pulse_out = pulseio.PulseOut(IR_PIN, frequency=38000, duty_cycle=2**15)
+button = keypad.Keys((INPUT_BUTTON,), value_when_pressed=False, pull=True)
 last = time.time()
 
-def send_pulse(pulse, mode: str):
-    pulse_out.send(pulse)
+def send_pulse():
+    pulse_out.send(IR_PULSE)
     status.notify_pulse()
-    data.send_toggle(mode)
-    last = time.time()
+
+data = Data(toggle_callback=send_pulse)
 
 # Rainbow colours on the NeoPixel
 while True:
@@ -56,7 +51,8 @@ while True:
         print(f'button pressed for {length} seconds')
         if length <= 1:
             #toggle
-            send_pulse(IR_PULSE, "local")
+            send_pulse()
+            data.send_toggle("local")
         else:
             # Long press option
             pass            

--- a/src/data.py
+++ b/src/data.py
@@ -3,6 +3,7 @@ import ssl
 import socketpool
 import wifi
 import time
+import json
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 from beeboard import BeeBoard
 
@@ -19,47 +20,52 @@ DISCOVERY_CONFIG_DATA = '''
 '''
 
 class Data:
-    def __init__(self) -> None:
-        ''' Setup the MQTT server here. '''
+    def __init__(self, toggle_callback=None) -> None:
+        ''' Setup the MQTT server here.
+            toggle_callback is called when a command to toggle the light is
+            received via MQTT.
+        '''
 
         BROKER = os.getenv('MQTT_BROKER')
-        PORT=int(os.getenv('MQTT_PORT', 1883))
-        USERNAME=os.getenv('MQTT_USER')
-        PASSWORD=os.getenv('MQTT_PASSWORD')
+        PORT = int(os.getenv('MQTT_PORT', 1883))
+        USERNAME = os.getenv('MQTT_USER')
+        PASSWORD = os.getenv('MQTT_PASSWORD')
+
+        self._toggle_callback = toggle_callback
+
+        # Device details
+        self.device_id = os.getenv('MQTT_DEVICE', 'string_light')
+        self.discovery_prefix = os.getenv('MQTT_DISCOVERY_UNIT', 'homeassistant')
 
         # TODO: Check that values have been provided
 
         self._bee_board = BeeBoard()
-        DEVICE = os.getenv('MQTT_DEVICE', 'string_light')
 
         self.MQTT_BASE_TOPIC = BASE_TOPIC.format(
-                os.getenv('MQTT_DISCOVERY_UNIT', 'homeassistant'), 
-                os.getenv('MQTT_LOCATION_UNIT', 'location'), 
-                DEVICE)
+                self.discovery_prefix,
+                os.getenv('MQTT_LOCATION_UNIT', 'location'),
+                self.device_id)
 
         # How often to send data. Can eventually be updated by an MQTT data message.
         self._mqtt_data_interval = os.getenv('MQTT_SEND_DATA', 300)
         self._mqtt_deep_sleep_interval = os.getenv('MQTT_DEEP_SLEEP', 0)
 
-        # TODO: make a topic a class. 
+        # topics to publish/subscribe
+        self.command_topic = f"{self.device_id}/set"
+        self.state_topic = f"{self.device_id}/state"
+        self.availability_topic = f"{self.device_id}/availability"
+        self.MQTT_TOPIC_V_BAT = f"{self.device_id}/v_bat"
+        self.MQTT_TOPIC_IR_TOGGLED = f"{self.device_id}/ir_toggled"
+        self.MQTT_IR_REQ_TOGGLE = f"{self.MQTT_BASE_TOPIC}/ir_req_toggle"
+        self._state = "OFF"
+
+        # TODO: make a topic a class.
         self.SUBSCRIPTION_TOPICS = [
+            (self.command_topic, self._on_set),
             (f"{self.MQTT_BASE_TOPIC}/req_toggle", self._on_req_toggle),
             (f"{self.MQTT_BASE_TOPIC}/req_send_data", self._on_send_data),
-            (f"{DEVICE}/req_debug", self._on_debug),
+            (f"{self.device_id}/req_debug", self._on_debug),
         ]
-
-        # Stack of data messages to publish (discovery topic, discovery Message)
-        # Stack gets emptied so the discovery messages are only sent once per boot. 
-        self.DISCOVERY_MESSAGES = [
-            (f"{self.MQTT_BASE_TOPIC}/req_toggle", f"message")
-        ]
-        # topics to subscribe
-        self.MQTT_IR_REQ_TOGGLE = f"{self.MQTT_BASE_TOPIC}/ir_req_toggle"
-
-        # topics to publish
-        self.MQTT_TOPIC_V_BAT = f"{self.MQTT_BASE_TOPIC}/v_bat"
-        self.MQTT_TOPIC_IR_TOGGLED = f"{self.MQTT_BASE_TOPIC}/ir_toggled"
-        self.MQTT_TOPIC_STATUS = f"{self.MQTT_BASE_TOPIC}/ir_status"
 
         ssl_context = ssl.create_default_context()
         # SSL Secrets get loaded here?
@@ -77,6 +83,7 @@ class Data:
             ssl_context=ssl_context,
             socket_timeout=self.timeout
         )
+        self._mqtt_client.will_set(self.availability_topic, "offline", retain=True)
 
 
         self._mqtt_client.on_connect = self._on_connected
@@ -91,8 +98,9 @@ class Data:
         ''' Used to connect to the mqtt server. '''
         try:
             self._mqtt_client.connect()
-            self._send_data(self.MQTT_TOPIC_STATUS, 'connected')
-            self._last = time.time() 
+            self._send_data(self.availability_topic, 'online')
+            self._send_discovery()
+            self._last = time.time()
         except Exception as ex:
             print("Unable to connect to MQTT Server")
 
@@ -125,7 +133,9 @@ class Data:
 
 
     def send_toggle(self, mode: str) -> None:
-        ''' Sent anytime the IR pulse was sent, mode is remote or local'''
+        '''Sent anytime the IR pulse was sent. mode indicates source.'''
+        self._state = 'ON' if self._state == 'OFF' else 'OFF'
+        self._send_data(self.state_topic, self._state)
         self._send_data(self.MQTT_TOPIC_IR_TOGGLED, mode)
 
 
@@ -136,10 +146,46 @@ class Data:
         except Exception as ex:
             print(f'Unable to send {topic}')
 
+    def _send_discovery(self):
+        '''Publish Home Assistant discovery messages.'''
+        battery_config_topic = f"{self.discovery_prefix}/sensor/{self.device_id}/battery/config"
+        battery_payload = {
+            'name': f'{self.device_id} Battery',
+            'state_topic': self.MQTT_TOPIC_V_BAT,
+            'unit_of_measurement': 'V',
+            'device_class': 'voltage',
+            'unique_id': f'{self.device_id}_battery',
+            'availability_topic': self.availability_topic,
+            'device': {
+                'identifiers': [self.device_id],
+                'name': self.device_id
+            }
+        }
+        self._mqtt_client.publish(battery_config_topic, json.dumps(battery_payload), retain=True)
+
+        switch_config_topic = f"{self.discovery_prefix}/switch/{self.device_id}/main/config"
+        switch_payload = {
+            'name': self.device_id,
+            'command_topic': self.command_topic,
+            'state_topic': self.state_topic,
+            'payload_on': 'ON',
+            'payload_off': 'OFF',
+            'unique_id': f'{self.device_id}_switch',
+            'availability_topic': self.availability_topic,
+            'device': {
+                'identifiers': [self.device_id],
+                'name': self.device_id
+            }
+        }
+        self._mqtt_client.publish(switch_config_topic, json.dumps(switch_payload), retain=True)
+
 
         # THESE NEED TO BE EVENTS subscribed and raised.
     def _on_connected(self, client, userdata, flags, rc) -> None:
-        print(f"Connected to MQTT server")# {self.BROKER} at {client.broker}")
+        print(f"Connected to MQTT server")
+
+        self._send_data(self.availability_topic, 'online')
+        self._send_discovery()
         
         for msg in self.SUBSCRIPTION_TOPICS:
             print(f'subscribing to: {msg[0]}')
@@ -151,17 +197,35 @@ class Data:
         print("Disconnected from MQTT server")
         for msg in self.SUBSCRIPTION_TOPICS:
             self._mqtt_client.unsubscribe(msg[0])
+        self._send_data(self.availability_topic, 'offline')
+
+    def _on_set(self, client, topic, message):
+        '''Handle on/off commands from Home Assistant.'''
+        print(f'Received set command: {message}')
+        if self._toggle_callback:
+            self._toggle_callback()
+        if message.upper() == 'ON':
+            self._state = 'ON'
+        elif message.upper() == 'OFF':
+            self._state = 'OFF'
+        else:
+            # unknown payload just toggle
+            self._state = 'ON' if self._state == 'OFF' else 'OFF'
+        self._send_data(self.state_topic, self._state)
+        self._send_data(self.MQTT_TOPIC_IR_TOGGLED, 'mqtt')
 
 
     def _on_req_toggle(self, client, topic, message):
-         ''' 
-            When a request toggle message comes in via MQTT we need to validate that its authentic
-            which will hopefully be accomplished via a list of authorized users. 
-         '''
-         print(f'Received subscribed request toggle command:')# {topic}, {message}')
-         #TODO - validate message
-         #TODO - Toggle Light
-        # Raise event so it can be sent
+        '''
+        When a request toggle message comes in via MQTT we need to validate that its authentic
+        which will hopefully be accomplished via a list of authorized users.
+        '''
+        print('Received subscribed request toggle command')
+        if self._toggle_callback:
+            self._toggle_callback()
+        self._state = 'ON' if self._state == 'OFF' else 'OFF'
+        self._send_data(self.state_topic, self._state)
+        self._send_data(self.MQTT_TOPIC_IR_TOGGLED, 'mqtt')
 
 
     def _on_send_data(self, client, topic, message):
@@ -182,3 +246,4 @@ class Data:
     @property
     def is_connected(self) -> bool:
         return self._mqtt_client.is_connected
+


### PR DESCRIPTION
## Summary
- add Home Assistant MQTT discovery support
- track and publish light state
- handle MQTT on/off commands via callback
- hook `code.py` to use new callback
- fix MQTT variable ordering and missing newline

## Testing
- `python -m py_compile src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6844488539408328b411531736028ac4